### PR TITLE
Add base58 in docs install requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ docs_require = [
     'sphinx_rtd_theme',
     'sphinxcontrib-httpdomain',
     'matplotlib',
+    'base58'
 ]
 
 setup(


### PR DESCRIPTION
## Description
A few sentences describing the overall goals of the pull request's commits.

## Issues This PR Fixes
Running Sphinx v1.8.6
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/planetmint-driver-python/envs/latest/lib/python3.7/site-packages/sphinx/config.py", line 368, in eval_config_file
    execfile_(filename, namespace)
  File "/home/docs/checkouts/readthedocs.org/user_builds/planetmint-driver-python/envs/latest/lib/python3.7/site-packages/sphinx/util/pycompat.py", line 150, in execfile_
    exec_(code, _globals)
  File "/home/docs/checkouts/readthedocs.org/user_builds/planetmint-driver-python/checkouts/latest/docs/conf.py", line 20, in <module>
    import planetmint_driver
  File "/home/docs/checkouts/readthedocs.org/user_builds/planetmint-driver-python/checkouts/latest/planetmint_driver/__init__.py", line 5, in <module>
    from .driver import Planetmint   # noqa
  File "/home/docs/checkouts/readthedocs.org/user_builds/planetmint-driver-python/checkouts/latest/planetmint_driver/driver.py", line 6, in <module>
    from .offchain import prepare_transaction, fulfill_transaction
  File "/home/docs/checkouts/readthedocs.org/user_builds/planetmint-driver-python/checkouts/latest/planetmint_driver/offchain.py", line 12, in <module>
    from .common.transaction import (
  File "/home/docs/checkouts/readthedocs.org/user_builds/planetmint-driver-python/checkouts/latest/planetmint_driver/common/transaction.py", line 29, in <module>
    import base58
ModuleNotFoundError: No module named 'base58'


## Impacted Areas in Application
Docs build